### PR TITLE
Bump simplecrawler from 1.1.6 to ^1.1.6. Installs 1.1.9.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1628,7 +1628,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -3240,6 +3241,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -7152,9 +7154,9 @@
       }
     },
     "robots-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-1.0.2.tgz",
-      "integrity": "sha512-c979P2TTe5Ezjg+VV5XWC59bab1w1Xyb8KLnJ5SKuwN7YH+ys8Y5KCZ2OP2J7zXVE7Yq0eYWlrqUM/urIbx9sg=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-2.1.1.tgz",
+      "integrity": "sha512-6yWEYSdhK3bAEcYY0In3wgSBK70BiQoJArzdjZKCP/35b3gKIYu5Lc0qQqsoxjoLVebVoJiKK4VWGc5+oxvWBQ=="
     },
     "rsvp": {
       "version": "4.8.5",
@@ -7445,14 +7447,29 @@
       "dev": true
     },
     "simplecrawler": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/simplecrawler/-/simplecrawler-1.1.6.tgz",
-      "integrity": "sha512-TsXJVzrKZuExJPq7juipV76KIE+D3a9IWWve6v+BBCuwFWhFYl9BOFZtARWBwb08KtI4eTZ/GGu9QuboJzo62w==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/simplecrawler/-/simplecrawler-1.1.9.tgz",
+      "integrity": "sha512-IY5YmeJWvfc1zpy9so1p/EknCqNum3Y9tmnzuLWZqKEwbntGXPGvN0SOtr+XqT4BHjfek2C12g3Tg1yK7Hoh8g==",
       "requires": {
-        "async": "^2.1.4",
-        "iconv-lite": "^0.4.13",
-        "robots-parser": "^1.0.0",
-        "urijs": "^1.18.11"
+        "async": "^3.1.0",
+        "iconv-lite": "^0.5.0",
+        "robots-parser": "^2.1.1",
+        "urijs": "^1.19.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+        },
+        "iconv-lite": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
+          "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
       }
     },
     "sisteransi": {
@@ -7584,7 +7601,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -8184,9 +8202,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
-      "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg=="
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.5.tgz",
+      "integrity": "sha512-48z9VGWwdCV5KfizHsE05DWS5fhK6gFlx5MjO7xu0Krc5FGPWzjlXEVV0nPMrdVuP7xmMHiPZ2HoYZwKOFTZOg=="
     },
     "urix": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lodash": "^4.17.19",
     "mitt": "1.1.3",
     "normalize-url": "3.3.0",
-    "simplecrawler": "1.1.6",
+    "simplecrawler": "^1.1.9",
     "url-parse": "1.4.3"
   },
   "engines": {


### PR DESCRIPTION
Bumps simplecrawler to ^1.1.6, installing 1.1.9. This is done to bump urijs from 1.19.1 to 1.19.5, addressing https://github.com/advisories/GHSA-3329-pjwv-fjpg.