### PR TITLE
Bump url-parse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6816,9 +6816,9 @@
       "dev": true
     },
     "querystringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
-      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "react-is": {
       "version": "16.13.1",
@@ -8213,11 +8213,11 @@
       "dev": true
     },
     "url-parse": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
-      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
       "requires": {
-        "querystringify": "^2.0.0",
+        "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "mitt": "1.1.3",
     "normalize-url": "3.3.0",
     "simplecrawler": "^1.1.9",
-    "url-parse": "1.4.3"
+    "url-parse": "^1.5.0"
   },
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
Bumps url-parse to 1.5.0.

Addresses https://github.com/advisories/GHSA-9m6j-fcg5-2442 in zendesk/marketing-web.

This issue is not fixed in https://github.com/lgraubner/sitemap-generator, which this repo was forked from. The original sitemap-generator was last updated in September 2020. It is using url-parse 1.4.7: https://github.com/lgraubner/sitemap-generator/blob/7c66f7acf3f136a8cd83b3d48401ad86d839315c/package.json#L35.