### PR TITLE
[WT-5268] Add "ignoreCanonacalized" option to exclude pages with mismatched canonical URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ Default: `true`
 
 Indicates whether [Google AMP pages](https://www.ampproject.org/) should be ignored and not be added to the sitemap.
 
+### ignoreCanonacalized
+
+Type: `boolean`
+Default: `true`
+
+Indicates whether pages with non-matching canonical URLs should be ignored and not be added to the sitemap.
+
 ### lastMod
 
 Type: `boolean`  

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Default: `true`
 
 Indicates whether [Google AMP pages](https://www.ampproject.org/) should be ignored and not be added to the sitemap.
 
-### ignoreCanonacalized
+### ignoreCanonicalized
 
 Type: `boolean`
 Default: `true`

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -52,11 +52,41 @@ describe('#SitemapGenerator', () => {
     expect(data.formattedLastMod).toBe('2023-01-05');
   });
 
-  test('::parsePage should respect the ignoreCanonicalized option', () => {
+  test('::parsePage ignores pages with mismatched canonical URL when ignoreCanonicalized option is on', () => {
     const page =
       '<!doctype html><html class="no-js" lang="en-US"><head><link rel="canonical" href="http://not.foo.bar" /></head><body>Hello world</body></html>';
     const data = gen.parsePage(queueItem, page, true);
 
     expect(data.ignored).toBe(true);
+  });
+
+  test('::parsePage intakes pages with missing canonical URL regardless of ignoreCanonicalized option', () => {
+    const page =
+      '<!doctype html><html class="no-js" lang="en-US"><head></head><body>Hello world</body></html>';
+    const data = gen.parsePage(queueItem, page, true);
+
+    expect(data.url).toBe(queueItem.url);
+
+    const ignoreCanonicalizedOff = SitemapGenerator('http://foo.bar', {
+      ignoreCanonicalized: false
+    });
+    const dataOff = ignoreCanonicalizedOff.parsePage(queueItem, page, true);
+
+    expect(dataOff.url).toBe(queueItem.url);
+  });
+
+  test('::parsePage intakes pages with matching canonical URL regardless of ignoreCanonicalized option', () => {
+    const page =
+      '<!doctype html><html class="no-js" lang="en-US"><head><link rel="canonical" href="http://foo.bar" /></head><body>Hello world</body></html>';
+    const data = gen.parsePage(queueItem, page, true);
+
+    expect(data.url).toBe(queueItem.url);
+
+    const ignoreCanonicalizedOff = SitemapGenerator('http://foo.bar', {
+      ignoreCanonicalized: false
+    });
+    const dataOff = ignoreCanonicalizedOff.parsePage(queueItem, page, true);
+
+    expect(dataOff.url).toBe(queueItem.url);
   });
 });

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -52,7 +52,7 @@ describe('#SitemapGenerator', () => {
     expect(data.formattedLastMod).toBe('2023-01-05');
   });
 
-  test('::parsePage should respect the ignoreCanonacalized option', () => {
+  test('::parsePage should respect the ignoreCanonicalized option', () => {
     const page =
       '<!doctype html><html class="no-js" lang="en-US"><head><link rel="canonical" href="http://not.foo.bar" /></head><body>Hello world</body></html>';
     const data = gen.parsePage(queueItem, page, true);

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -54,7 +54,7 @@ describe('#SitemapGenerator', () => {
 
   test('::parsePage should respect the ignoreCanonacalized option', () => {
     const page =
-      '<!doctype html><html class="no-js" lang="en-US"><head><meta property="article:published_time" content="2021-09-21T15:42:48+00:00" /><link rel="canonical" href="http://not.foo.bar" /></head><body>Hello world</body></html>';
+      '<!doctype html><html class="no-js" lang="en-US"><head><link rel="canonical" href="http://not.foo.bar" /></head><body>Hello world</body></html>';
     const data = gen.parsePage(queueItem, page, true);
 
     expect(data.ignored).toBe(true);

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -73,6 +73,7 @@ describe('#SitemapGenerator', () => {
     const dataOff = ignoreCanonicalizedOff.parsePage(queueItem, page, true);
 
     expect(dataOff.url).toBe(queueItem.url);
+    expect(dataOff).not.toHaveProperty('ignored');
   });
 
   test('::parsePage intakes pages with matching canonical URL regardless of ignoreCanonicalized option', () => {
@@ -88,5 +89,6 @@ describe('#SitemapGenerator', () => {
     const dataOff = ignoreCanonicalizedOff.parsePage(queueItem, page, true);
 
     expect(dataOff.url).toBe(queueItem.url);
+    expect(dataOff).not.toHaveProperty('ignored');
   });
 });

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -51,4 +51,12 @@ describe('#SitemapGenerator', () => {
     expect(data.lastMod).toBe(queueItem.stateData.headers['last-modified']);
     expect(data.formattedLastMod).toBe('2023-01-05');
   });
+
+  test('::parsePage should respect the ignoreCanonacalized option', () => {
+    const page =
+      '<!doctype html><html class="no-js" lang="en-US"><head><meta property="article:published_time" content="2021-09-21T15:42:48+00:00" /><link rel="canonical" href="http://not.foo.bar" /></head><body>Hello world</body></html>';
+    const data = gen.parsePage(queueItem, page, true);
+
+    expect(data.ignored).toBe(true);
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,16 @@ module.exports = function SitemapGenerator(uri, opts) {
     ) {
       emitter.emit('ignore', url);
     } else {
+      // https://zendesk.atlassian.net/browse/WT-5268 - ignore canonicalized pages
+      const canonicalMatches = /<link rel="canonical" href="([^"]*)"/gi.exec(page);
+      if (canonicalMatches && canonicalMatches.length > 1) {
+        const canonical = matches[1];
+        if (canonical !== url) {
+          emitter.emit('ignore', url);
+          return;
+        }
+      }
+
       emitter.emit('add', url);
 
       if (sitemapPath !== null) {

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,8 @@ module.exports = function SitemapGenerator(uri, opts) {
     lastModFormat: 'YYYY-MM-DD',
     changeFreq: '',
     priorityMap: [],
-    ignoreAMP: true
+    ignoreAMP: true,
+    ignoreCanonacalized: true
   };
 
   if (!uri) {
@@ -86,12 +87,14 @@ module.exports = function SitemapGenerator(uri, opts) {
       emitter.emit('ignore', url);
     } else {
       // https://zendesk.atlassian.net/browse/WT-5268 - ignore canonicalized pages
-      const canonicalMatches = /<link rel="canonical" href="([^"]*)"/gi.exec(page);
-      if (canonicalMatches && canonicalMatches.length > 1) {
-        const canonical = matches[1];
-        if (canonical !== url) {
-          emitter.emit('ignore', url);
-          return;
+      if (options.ignoreCanonacalized) {
+        const canonicalMatches = /<link rel="canonical" href="([^"]*)"/gi.exec(page);
+        if (canonicalMatches && canonicalMatches.length > 1) {
+          const canonical = matches[1];
+          if (canonical !== url) {
+            emitter.emit('ignore', url);
+            return;
+          }
         }
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,6 @@ module.exports = function SitemapGenerator(uri, opts) {
     ) {
       emitter.emit('ignore', url);
     } else {
-      // https://zendesk.atlassian.net/browse/WT-5268 - ignore canonicalized pages
       if (options.ignoreCanonacalized) {
         const canonicalMatches = /<link rel="canonical" href="([^"]*)"/gi.exec(
           page

--- a/src/index.js
+++ b/src/index.js
@@ -80,30 +80,35 @@ module.exports = function SitemapGenerator(uri, opts) {
   const parsePage = (queueItem, page, returnSitemapData = false) => {
     const { url, depth } = queueItem;
 
+    let ignored = false;
+
     if (
       /(<meta(?=[^>]+noindex).*?>)/.test(page) || // check if robots noindex is present
       (options.ignoreAMP && /<html[^>]+(amp|⚡)[^>]*>/.test(page)) // check if it's an amp page
     ) {
-      emitter.emit('ignore', url);
-    } else {
-      if (options.ignoreCanonicalized) {
-        const canonicalMatches = /<link rel="canonical" href="([^"]*)"/gi.exec(
-          page
-        );
-        if (canonicalMatches && canonicalMatches.length > 1) {
-          const canonical = canonicalMatches[1];
-          if (canonical && canonical !== url) {
-            emitter.emit('ignore', url);
-            if (returnSitemapData) {
-              return {
-                ignored: true
-              };
-            }
-            return;
-          }
+      ignored = true;
+    }
+
+    if (options.ignoreCanonicalized) {
+      const canonicalMatches = /<link rel="canonical" href="([^"]*)"/gi.exec(
+        page
+      );
+      if (canonicalMatches && canonicalMatches.length > 1) {
+        const canonical = canonicalMatches[1];
+        if (canonical && canonical !== url) {
+          ignored = true;
         }
       }
+    }
 
+    if (ignored) {
+      emitter.emit('ignore', url);
+      if (returnSitemapData) {
+        return {
+          ignored: true
+        };
+      }
+    } else {
       emitter.emit('add', url);
 
       if (sitemapPath !== null) {

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ module.exports = function SitemapGenerator(uri, opts) {
     changeFreq: '',
     priorityMap: [],
     ignoreAMP: true,
-    ignoreCanonacalized: true
+    ignoreCanonicalized: true
   };
 
   if (!uri) {
@@ -86,7 +86,7 @@ module.exports = function SitemapGenerator(uri, opts) {
     ) {
       emitter.emit('ignore', url);
     } else {
-      if (options.ignoreCanonacalized) {
+      if (options.ignoreCanonicalized) {
         const canonicalMatches = /<link rel="canonical" href="([^"]*)"/gi.exec(
           page
         );

--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ module.exports = function SitemapGenerator(uri, opts) {
         const canonicalMatches = /<link rel="canonical" href="([^"]*)"/gi.exec(page);
         if (canonicalMatches && canonicalMatches.length > 1) {
           const canonical = matches[1];
-          if (canonical !== url) {
+          if (canonical && canonical !== url) {
             emitter.emit('ignore', url);
             return;
           }

--- a/src/index.js
+++ b/src/index.js
@@ -88,11 +88,18 @@ module.exports = function SitemapGenerator(uri, opts) {
     } else {
       // https://zendesk.atlassian.net/browse/WT-5268 - ignore canonicalized pages
       if (options.ignoreCanonacalized) {
-        const canonicalMatches = /<link rel="canonical" href="([^"]*)"/gi.exec(page);
+        const canonicalMatches = /<link rel="canonical" href="([^"]*)"/gi.exec(
+          page
+        );
         if (canonicalMatches && canonicalMatches.length > 1) {
-          const canonical = matches[1];
+          const canonical = canonicalMatches[1];
           if (canonical && canonical !== url) {
             emitter.emit('ignore', url);
+            if (returnSitemapData) {
+              return {
+                ignored: true
+              };
+            }
             return;
           }
         }


### PR DESCRIPTION
## Description

Adds a new `ignoreCanonacalized` option to `SitemapGenerator` (defaults to `true` - let me know if you think it's safer to default to `false`) which excludes pages from the sitemap which have canonical URLs that do match their own.

## Testing steps

1. Pull locally and run `npm test`