### PR TITLE
WT-5354 Expose getSitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ crawler.addFetchCondition((queueItem, referrerQueueItem, callback) => {
 });
 ```
 
+### getSitemap()
+
+Returns the sitemap instance (`SitemapRotator`).
+
+This can be useful to add static URLs to the sitemap:
+
+```JavaScript
+const crawler = generator.getCrawler()
+const sitemap = generator.getSitemap()
+
+// Add static URL on crawl init.
+crawler.on('crawlstart', () => {
+  sitemap.addURL('/my/static/url')
+})
+````
+
 ### queueURL(url)
 
 Add a URL to crawler's queue. Useful to help crawler fetch pages it can't find itself.

--- a/src/index.js
+++ b/src/index.js
@@ -213,6 +213,7 @@ module.exports = function SitemapGenerator(uri, opts) {
     start: () => crawler.start(),
     stop: () => crawler.stop(),
     getCrawler: () => crawler,
+    getSitemap: () => sitemap,
     queueURL: url => {
       crawler.queueURL(url, undefined, false);
     },


### PR DESCRIPTION
## Description
Pulls in the `getSitemap` logic from: https://github.com/lgraubner/sitemap-generator/pull/61/files -- this lets us add items to the sitemap, without having to actually crawl them. This is useful for when we have a definitive set of static URLs that need to be added. Added bonus -- since we're not crawling pages added this way, the build time for sitemaps doesn't get extended!

## Usage
`sitemap.addURL(url);`